### PR TITLE
Add to_dataframe method to BinaryAPIReponse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "anyio>=3.5.0, <5",
     "distro>=1.7.0, <2",
     "sniffio",
-    "pandas>=2.1.0, <3",
+    "pandas==2.2.3",
+    "numpy==2.0.2",
 ]
 requires-python = ">= 3.8"
 classifiers = [
@@ -56,7 +57,8 @@ dev-dependencies = [
     "importlib-metadata>=6.7.0",
     "rich>=13.7.1",
     "nest_asyncio==1.6.0",
-    "pandas",
+    "pandas==2.2.3",
+    "numpy==2.0.2",
 ]
 
 [tool.rye.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "anyio>=3.5.0, <5",
     "distro>=1.7.0, <2",
     "sniffio",
+    "pandas>=2.1.0, <3",
 ]
 requires-python = ">= 3.8"
 classifiers = [
@@ -55,6 +56,7 @@ dev-dependencies = [
     "importlib-metadata>=6.7.0",
     "rich>=13.7.1",
     "nest_asyncio==1.6.0",
+    "pandas",
 ]
 
 [tool.rye.scripts]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -102,5 +102,7 @@ virtualenv==20.24.5
     # via nox
 zipp==3.17.0
     # via importlib-metadata
-pandas==2.1.0
+pandas==2.2.3
+    # via contextual-client
+numpy==2.0.2
     # via contextual-client

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -102,3 +102,5 @@ virtualenv==20.24.5
     # via nox
 zipp==3.17.0
     # via importlib-metadata
+pandas==2.1.0
+    # via contextual-client

--- a/requirements.lock
+++ b/requirements.lock
@@ -43,5 +43,7 @@ typing-extensions==4.12.2
     # via contextual-client
     # via pydantic
     # via pydantic-core
-pandas==2.1.0
+pandas==2.2.3
+    # via contextual-client
+numpy==2.0.2
     # via contextual-client

--- a/requirements.lock
+++ b/requirements.lock
@@ -43,3 +43,5 @@ typing-extensions==4.12.2
     # via contextual-client
     # via pydantic
     # via pydantic-core
+pandas==2.1.0
+    # via contextual-client

--- a/src/contextual/_response.py
+++ b/src/contextual/_response.py
@@ -24,8 +24,8 @@ from typing_extensions import Awaitable, ParamSpec, override, get_origin
 
 import anyio
 import httpx
-import pandas as pd
 import pydantic
+from pandas import DataFrame  # type: ignore[import]
 
 from ._types import NoneType
 from ._utils import is_given, extract_type_arg, is_annotated_type, is_type_alias_type, extract_type_var_from_base
@@ -482,13 +482,13 @@ class BinaryAPIResponse(APIResponse[bytes]):
     the API request, e.g. `.with_streaming_response.get_binary_response()`
     """
 
-    def to_dataframe(self) -> pd.DataFrame:
+    def to_dataframe(self) -> DataFrame:
         """Convert the response data to a pandas DataFrame.
 
         Note: This method requires the `pandas` library to be installed.
 
         Returns:
-            pd.DataFrame: Processed evaluation data
+            DataFrame: Processed evaluation data
         """
         # Read the binary content
         content = self.read()
@@ -506,18 +506,18 @@ class BinaryAPIResponse(APIResponse[bytes]):
                     results = ast.literal_eval(entry["results"])
                     del entry["results"]
                     if isinstance(results, dict):
-                        for key, value in results.items():
+                        for key, value in results.items():  # type: ignore
                             if isinstance(value, dict):
-                                for subkey, subvalue in value.items():
+                                for subkey, subvalue in value.items():  # type: ignore
                                     entry[f"{key}_{subkey}"] = subvalue
                             else:
                                 entry[key] = value
 
-                data.append(entry)
+                data.append(entry)  # type: ignore
             except Exception as e:
                 log.info(f"Error processing line: {e}")
                 continue
-        return pd.DataFrame(data)
+        return DataFrame(data)
 
     def write_to_file(
         self,


### PR DESCRIPTION
This adds a method `to_dataframe` that can be used for eval responses like so:

```python
eval_results = client.agents.datasets.evaluate.retrieve(dataset_name=dataset_name, agent_id=agent_id)
df = eval_results.to_dataframe()
df.head()
```