### PR TITLE
fix numpy/pandas version issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
     "anyio>=3.5.0, <5",
     "distro>=1.7.0, <2",
     "sniffio",
-    "pandas==2.2.3",
-    "numpy==2.0.2",
+    "numpy~=1.26.4",
+    "pandas~=1.5.3"
 ]
 requires-python = ">= 3.8"
 classifiers = [
@@ -57,8 +57,8 @@ dev-dependencies = [
     "importlib-metadata>=6.7.0",
     "rich>=13.7.1",
     "nest_asyncio==1.6.0",
-    "pandas==2.2.3",
-    "numpy==2.0.2",
+    "numpy~=1.26.4",
+    "pandas~=1.5.3"
 ]
 
 [tool.rye.scripts]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -56,9 +56,14 @@ nest-asyncio==1.6.0
 nodeenv==1.8.0
     # via pyright
 nox==2023.4.22
+numpy==1.26.4
+    # via contextual-client
+    # via pandas
 packaging==23.2
     # via nox
     # via pytest
+pandas==2.2.3
+    # via contextual-client
 platformdirs==3.11.0
     # via virtualenv
 pluggy==1.5.0
@@ -74,9 +79,11 @@ pytest==8.3.3
     # via pytest-asyncio
 pytest-asyncio==0.24.0
 python-dateutil==2.8.2
+    # via pandas
     # via time-machine
 pytz==2023.3.post1
     # via dirty-equals
+    # via pandas
 respx==0.22.0
 rich==13.7.1
 ruff==0.9.4
@@ -98,11 +105,9 @@ typing-extensions==4.12.2
     # via pydantic
     # via pydantic-core
     # via pyright
+tzdata==2025.1
+    # via pandas
 virtualenv==20.24.5
     # via nox
 zipp==3.17.0
     # via importlib-metadata
-pandas==2.2.3
-    # via contextual-client
-numpy==2.0.2
-    # via contextual-client

--- a/requirements.lock
+++ b/requirements.lock
@@ -31,10 +31,21 @@ httpx==0.28.1
 idna==3.4
     # via anyio
     # via httpx
+numpy==1.26.4
+    # via contextual-client
+    # via pandas
+pandas==2.2.3
+    # via contextual-client
 pydantic==2.10.3
     # via contextual-client
 pydantic-core==2.27.1
     # via pydantic
+python-dateutil==2.9.0.post0
+    # via pandas
+pytz==2025.1
+    # via pandas
+six==1.17.0
+    # via python-dateutil
 sniffio==1.3.0
     # via anyio
     # via contextual-client
@@ -43,7 +54,5 @@ typing-extensions==4.12.2
     # via contextual-client
     # via pydantic
     # via pydantic-core
-pandas==2.2.3
-    # via contextual-client
-numpy==2.0.2
-    # via contextual-client
+tzdata==2025.1
+    # via pandas


### PR DESCRIPTION
This fixes an issue that occurs in google colab:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-12-1886ef2dd59a> in <cell line: 0>()
----> 1 eval = pd.read_csv('data/eval_short.csv')
      2 eval.head()

9 frames
/usr/local/lib/python3.11/dist-packages/pandas/core/dtypes/cast.py in maybe_convert_platform(values)
    136     if arr.dtype == _dtype_obj:
    137         arr = cast(np.ndarray, arr)
--> 138         arr = lib.maybe_convert_objects(arr)
    139 
    140     return arr

lib.pyx in pandas._libs.lib.maybe_convert_objects()

TypeError: Cannot convert numpy.ndarray to numpy.ndarray
```